### PR TITLE
Option to output extracted messages as js files instead of json

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ $ npm install babel-plugin-react-intl
   "extra": {
     "react-intl": {
         "messagesDir": "./build/messages/",
+        "outputFormat": "js",
+        "outputIndentation": 2,
         "enforceDescriptions": true
     }
   }
@@ -30,9 +32,13 @@ $ npm install babel-plugin-react-intl
 
 #### Options
 
-- **`messagesDir`**: The target location where the plugin will output a `.json` file corresponding to each component from which React Intl messages were extracted.
+- **`messagesDir`**: The target location where the plugin will output a messages file corresponding to each component from which React Intl messages were extracted.
 
 - **`enforceDescriptions`**: Whether or not message declarations _must_ contain a `description` to provide context to translators.
+
+- **`outputFormat`**: The format of the outputted messages file. Possible options: `JS`, `JSON`, default `JSON`.
+
+- **`outputIndentation`**: The level of indentation used in the outputted messages file. Allowed values between 0 and 10, default 2.
 
 ### Via CLI
 

--- a/src/index.js
+++ b/src/index.js
@@ -197,7 +197,9 @@ export default function ({Plugin, types: t}) {
                     const {messagesDir, outputFormat, outputIndentation} = getReactIntlOptions(file.opts);
                     const {basename, filename} = file.opts;
                     const jsFormat = outputFormat.toUpperCase() === 'JS';
-                    const indentation = parseInt(outputIndentation) || 2;
+                    let indentation = parseInt(outputIndentation) || 2;
+                    if (indentation > 10) indentation = 10;
+                    if (indentation < 0) indentation = 0;
 
                     let descriptors = [...messages.values()];
                     file.metadata['react-intl'] = {messages: descriptors};

--- a/src/index.js
+++ b/src/index.js
@@ -197,7 +197,7 @@ export default function ({Plugin, types: t}) {
                     const {messagesDir, outputFormat, outputIndentation} = getReactIntlOptions(file.opts);
                     const {basename, filename} = file.opts;
                     const jsFormat = outputFormat.toUpperCase() === 'JS';
-                    let indentation = parseInt(outputIndentation) || 2;
+                    let indentation = parseInt(outputIndentation, 10) || 2;
                     if (indentation > 10) indentation = 10;
                     if (indentation < 0) indentation = 0;
 

--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,7 @@ export default function ({Plugin, types: t}) {
                 return `${indent}${key}: '${message}', /* ${description} */`;
             }
 
-            return `${indent}${key}: '${message},'`;
+            return `${indent}${key}: '${message}',`;
         };
 
         const generateFile = (lines) => {
@@ -196,7 +196,7 @@ export default function ({Plugin, types: t}) {
                     const {messages}  = file.get('react-intl');
                     const {messagesDir, outputFormat, outputIndentation} = getReactIntlOptions(file.opts);
                     const {basename, filename} = file.opts;
-                    const jsFormat = outputFormat.toUpperCase() === 'JS';
+                    const jsFormat = outputFormat && outputFormat.toUpperCase() === 'JS';
                     let indentation = parseInt(outputIndentation, 10) || 2;
                     if (indentation > 10) indentation = 10;
                     if (indentation < 0) indentation = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -143,6 +143,31 @@ export default function ({Plugin, types: t}) {
         return importedNames.some((name) => path.referencesImport(mod, name));
     }
 
+    function generateJavascriptFile(descriptors, indentation) {
+        const indent = Array(++indentation).join(' ');
+
+        const generateLine = (key, description, message) => {
+            if (description) {
+                return `${indent}${key}: '${message}', /* ${description} */`;
+            }
+
+            return `${indent}${key}: '${message},'`;
+        };
+
+        const generateFile = (lines) => {
+            lines.unshift('export default {');
+            lines.push('};');
+
+            return lines.join('\n');
+        };
+
+        const strings = descriptors.map(({id, description, defaultMessage}) => {
+            return generateLine(id, description, defaultMessage);
+        });
+
+        return generateFile(strings);
+    }
+
     return new Plugin('react-intl', {
         visitor: {
             Program: {
@@ -169,20 +194,25 @@ export default function ({Plugin, types: t}) {
 
                 exit(node, parent, scope, file) {
                     const {messages}  = file.get('react-intl');
-                    const {messagesDir} = getReactIntlOptions(file.opts);
+                    const {messagesDir, outputFormat, outputIndentation} = getReactIntlOptions(file.opts);
                     const {basename, filename} = file.opts;
+                    const jsFormat = outputFormat.toUpperCase() === 'JS';
+                    const indentation = parseInt(outputIndentation) || 2;
 
                     let descriptors = [...messages.values()];
                     file.metadata['react-intl'] = {messages: descriptors};
 
                     if (messagesDir) {
+                        const extension = jsFormat ? '.js' : '.json';
                         let messagesFilename = p.join(
                             messagesDir,
                             p.dirname(p.relative(process.cwd(), filename)),
-                            basename + '.json'
+                            basename + extension
                         );
 
-                        let messagesFile = JSON.stringify(descriptors, null, 2);
+                        let messagesFile = jsFormat ?
+                          generateJavascriptFile(descriptors, indentation) :
+                          JSON.stringify(descriptors, null, indentation);
 
                         mkdirpSync(p.dirname(messagesFilename));
                         writeFileSync(messagesFilename, messagesFile);


### PR DESCRIPTION
Adds the option to output extracted messages as Javascript files instead of JSON files.
Adds the option to specify the indentation used in the output files.