### PR TITLE
Trim relative portions from the paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,9 +154,11 @@ export default function () {
                     file.metadata['react-intl'] = {messages: descriptors};
 
                     if (opts.messagesDir && descriptors.length > 0) {
+                        let relativePath = p.relative(process.cwd(), filename);
+                        relativePath = relativePath.replace(/\.{2}\//, '');
                         let messagesFilename = p.join(
                             opts.messagesDir,
-                            p.dirname(p.relative(process.cwd(), filename)),
+                            p.dirname(relativePath),
                             basename + '.json'
                         );
 

--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,7 @@ export default function () {
 
                     if (opts.messagesDir && descriptors.length > 0) {
                         let relativePath = p.relative(process.cwd(), filename);
-                        relativePath = relativePath.replace(/\.{2}\//g, '');
+                        relativePath = p.normalize(p.sep + relativePath);
                         let messagesFilename = p.join(
                             opts.messagesDir,
                             p.dirname(relativePath),

--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,7 @@ export default function () {
 
                     if (opts.messagesDir && descriptors.length > 0) {
                         let relativePath = p.relative(process.cwd(), filename);
-                        relativePath = relativePath.replace(/\.{2}\//, '');
+                        relativePath = relativePath.replace(/\.{2}\//g, '');
                         let messagesFilename = p.join(
                             opts.messagesDir,
                             p.dirname(relativePath),


### PR DESCRIPTION
If a file that has message descriptors resolves to a relative path starting with `..`, it will create the `json` files right next to the `js` files, instead of in the `messagesDir`. This fixes that, and I think will fix #23.