### PR TITLE
Add support for sequenceExpressions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,11 +130,17 @@ export default function () {
     }
 
     function referencesImport(path, mod, importedNames) {
-        if (!(path.isIdentifier() || path.isJSXIdentifier())) {
-            return false;
-        }
+        if (path.isSequenceExpression()) {
+            const sequenceExpressionValue =
+                path.node.expressions[path.node.expressions.length - 1];
 
-        return importedNames.some((name) => path.referencesImport(mod, name));
+            if (sequenceExpressionValue.property && sequenceExpressionValue.property.name) {
+                return importedNames.some((name) => name === sequenceExpressionValue.property.name);
+            }
+        } else if (path.isIdentifier() || path.isJSXIdentifier()) {
+            return importedNames.some((name) => path.referencesImport(mod, name));
+        }
+        return false;
     }
 
     return {


### PR DESCRIPTION
:wave: Hi @ericf - I just ran into this problem in my babel-plugin and see that you have the same.

Babel's transform of `import` uses sequence expressions in it's output. Also, tools like isparta, adana and istanbul use these to instrument the code. In any case, this is the result of one of these transformations:

```js
var _reactIntl = require("react-intl");

var defaultMessages = (0, _reactIntl.defineMessages)({
  'greeting-button': {
    id: 'greeting-button',
    description: 'The button greeting developers on the front page of the getting started app',
    defaultMessage: 'Hi! {name} {environment}'
  }
});
```

At the moment the `referencesImport` function you have only checks for identifiers. This PR extends it to also handle the above case. Here is an AST snippit demoing the issue and the fix: http://astexplorer.net/#/NdbZIrInxo/4

Side note, I have a test for this case in my plugin but I see you don't have any tests yet. I wrote a testing tool for babel plugins that just asserts a before and after if you wanna use it. I can help you write the first few tests if you'd like:

Here's the link
https://github.com/walmartreact/assert-transform

And a lib using it:
https://github.com/walmartreact/babel-plugin-i18n-id-hashing