### PR TITLE
Add script to build fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "clean": "rimraf lib/",
     "test": "cross-env NODE_ENV=test mocha --compilers js:babel-register",
     "build": "babel src/ --out-dir lib/",
+    "build:fixtures": "babel-node ./scripts/build-fixtures.js",
     "preversion": "npm run lint && npm run clean && npm run build",
     "prepublish": "npm run clean && npm run build"
   },

--- a/scripts/build-fixtures.js
+++ b/scripts/build-fixtures.js
@@ -1,0 +1,37 @@
+import * as p from 'path';
+import * as fs from 'fs';
+import {transformFileSync} from 'babel-core';
+import plugin from '../src/index';
+
+const baseDir = p.resolve(`${__dirname}/../test/fixtures`);
+
+const fixtures = [
+    'defineMessages',
+    'FormattedHTMLMessage',
+    'FormattedMessage',
+    ['moduleSourceName', {
+        moduleSourceName: 'react-i18n',
+    }],
+];
+
+fixtures.forEach((fixture) => {
+    let name = fixture;
+    let options = {};
+    if (Array.isArray(fixture)) {
+        [name, options] = fixture;
+    }
+
+    let {code, metadata} = transformFileSync(`${baseDir}/${name}/actual.js`, {
+        plugins: [
+            [plugin, {
+                ...options,
+                messagesDir: false,
+            }],
+        ],
+    });
+
+    let messages = JSON.stringify(metadata['react-intl'].messages, null, 2);
+
+    fs.writeFileSync(`${baseDir}/${name}/expected.js`, `${code}\n`);
+    fs.writeFileSync(`${baseDir}/${name}/expected.json`, `${messages}\n`);
+});

--- a/test/fixtures/FormattedHTMLMessage/expected.js
+++ b/test/fixtures/FormattedHTMLMessage/expected.js
@@ -26,7 +26,7 @@ var Foo = function (_Component) {
     function Foo() {
         _classCallCheck(this, Foo);
 
-        return _possibleConstructorReturn(this, Object.getPrototypeOf(Foo).apply(this, arguments));
+        return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
     }
 
     _createClass(Foo, [{
@@ -44,4 +44,3 @@ var Foo = function (_Component) {
 }(_react.Component);
 
 exports.default = Foo;
-

--- a/test/fixtures/FormattedMessage/expected.js
+++ b/test/fixtures/FormattedMessage/expected.js
@@ -26,7 +26,7 @@ var Foo = function (_Component) {
     function Foo() {
         _classCallCheck(this, Foo);
 
-        return _possibleConstructorReturn(this, Object.getPrototypeOf(Foo).apply(this, arguments));
+        return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
     }
 
     _createClass(Foo, [{
@@ -44,4 +44,3 @@ var Foo = function (_Component) {
 }(_react.Component);
 
 exports.default = Foo;
-

--- a/test/fixtures/defineMessages/expected.js
+++ b/test/fixtures/defineMessages/expected.js
@@ -39,7 +39,7 @@ var Foo = function (_Component) {
     function Foo() {
         _classCallCheck(this, Foo);
 
-        return _possibleConstructorReturn(this, Object.getPrototypeOf(Foo).apply(this, arguments));
+        return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
     }
 
     _createClass(Foo, [{
@@ -66,4 +66,3 @@ var Foo = function (_Component) {
 }(_react.Component);
 
 exports.default = Foo;
-

--- a/test/fixtures/moduleSourceName/expected.js
+++ b/test/fixtures/moduleSourceName/expected.js
@@ -43,7 +43,7 @@ var Foo = function (_Component) {
     function Foo() {
         _classCallCheck(this, Foo);
 
-        return _possibleConstructorReturn(this, Object.getPrototypeOf(Foo).apply(this, arguments));
+        return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
     }
 
     _createClass(Foo, [{
@@ -66,4 +66,3 @@ var Foo = function (_Component) {
 }(_react.Component);
 
 exports.default = Foo;
-


### PR DESCRIPTION
A recent change in Babel caused the checked-in, built fixtures to become out of date. This adds a script that can be periodically run to rebuild the fixtures.