### PR TITLE
Remove description after extracting Message Descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ $ npm install babel-plugin-react-intl
 
 The default message descriptors for the app's default language will be extracted from: `defineMessages()`, `<FormattedMessage>`, and `<FormattedHTMLMessage>`; all of which are named exports of the React Intl package.
 
+If a message descriptor has a `description`, it'll be removed from the source after it's extracted to save bytes since it isn't used at runtime.
+
 ### Via `.babelrc` (Recommended)
 
 **.babelrc**

--- a/test/fixtures/FormattedHTMLMessage/expected.js
+++ b/test/fixtures/FormattedHTMLMessage/expected.js
@@ -34,8 +34,7 @@ var Foo = function (_Component) {
         value: function render() {
             return _react2.default.createElement(_reactIntl.FormattedHTMLMessage, {
                 id: 'foo.bar.baz',
-                defaultMessage: '<h1>Hello World!</h1>',
-                description: 'The default message.'
+                defaultMessage: '<h1>Hello World!</h1>'
             });
         }
     }]);

--- a/test/fixtures/FormattedMessage/expected.js
+++ b/test/fixtures/FormattedMessage/expected.js
@@ -34,8 +34,7 @@ var Foo = function (_Component) {
         value: function render() {
             return _react2.default.createElement(_reactIntl.FormattedMessage, {
                 id: 'foo.bar.baz',
-                defaultMessage: 'Hello World!',
-                description: 'The default message.'
+                defaultMessage: 'Hello World!'
             });
         }
     }]);

--- a/test/fixtures/defineMessages/expected.js
+++ b/test/fixtures/defineMessages/expected.js
@@ -22,14 +22,12 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 var msgs = (0, _reactIntl.defineMessages)({
     header: {
-        id: 'foo.bar.baz',
-        defaultMessage: 'Hello World!',
-        description: 'The default message'
+        'id': 'foo.bar.baz',
+        'defaultMessage': 'Hello World!'
     },
     content: {
-        id: 'foo.bar.biff',
-        defaultMessage: 'Hello Nurse!',
-        description: 'Another message'
+        'id': 'foo.bar.biff',
+        'defaultMessage': 'Hello Nurse!'
     }
 });
 

--- a/test/fixtures/moduleSourceName/expected.js
+++ b/test/fixtures/moduleSourceName/expected.js
@@ -54,8 +54,7 @@ var Foo = function (_Component) {
                 null,
                 _react2.default.createElement(_reactI18n.FormattedMessage, {
                     id: 'foo.bar.baz',
-                    defaultMessage: 'Hello World!',
-                    description: 'The default message.'
+                    defaultMessage: 'Hello World!'
                 }),
                 msgs
             );

--- a/test/fixtures/removeDescriptions/actual.js
+++ b/test/fixtures/removeDescriptions/actual.js
@@ -1,0 +1,22 @@
+import React, {Component} from 'react';
+import {defineMessages, FormattedMessage} from 'react-intl';
+
+const messages = defineMessages({
+    foo: {
+        id: 'greeting-user',
+        description: 'Greeting the user',
+        defaultMessage: 'Hello, {name}',
+    },
+});
+
+export default class Foo extends Component {
+    render() {
+        return (
+            <FormattedMessage
+                id='greeting-world'
+                description='Greeting to the world'
+                defaultMessage='Hello World!'
+            />
+        );
+    }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,7 @@ const skipTests = [
     'extractSourceLocation',
     'moduleSourceName',
     'icuSyntax',
+    'removeDescriptions',
 ];
 
 const fixturesDir = path.join(__dirname, 'fixtures');
@@ -66,6 +67,22 @@ describe('options', () => {
         try {
             transform(path.join(fixtureDir, 'actual.js'), {
                 enforceDescriptions: false,
+            });
+            assert(true);
+        } catch (e) {
+            console.error(e);
+            assert(false);
+        }
+    });
+
+    it('removes descriptions when plugin is applied more than once', () => {
+        const fixtureDir = path.join(fixturesDir, 'removeDescriptions');
+
+        try {
+            transform(path.join(fixtureDir, 'actual.js'), {
+                enforceDescriptions: true,
+            }, {
+                multiplePasses: true,
             });
             assert(true);
         } catch (e) {
@@ -133,13 +150,18 @@ const BASE_OPTIONS = {
     messagesDir: baseDir,
 };
 
-function transform(filePath, options = {}) {
+function transform(filePath, options = {}, {multiplePasses = false} = {}) {
+    function getPluginConfig() {
+        return [plugin, {
+            ...BASE_OPTIONS,
+            ...options,
+        }];
+    }
+
     return babel.transformFileSync(filePath, {
-        plugins: [
-            [plugin, {
-                ...BASE_OPTIONS,
-                ...options,
-            }],
-        ],
+        plugins: multiplePasses ? [
+            getPluginConfig(),
+            getPluginConfig(),
+        ] : [getPluginConfig()],
     }).code;
 }


### PR DESCRIPTION
This adds back the removal of `description` fields after extracting the Message Descriptor in a way that works if the plugin is added multiple times.

See #28

## Todos

- [x] Add details about `description` removal to README
- [x] Add tests