### PR TITLE
Babel now has seperate babel-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If a message descriptor has a `description`, it'll be removed from the source af
 ### Via CLI
 
 ```sh
-$ babel --plugins react-intl script.js
+$ babel-cli --plugins react-intl script.js
 ```
 
 ### Via Node API


### PR DESCRIPTION
You have mistakenly installed the `babel` package, which is a no-op in Babel 6.
Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.

    npm uninstall babel
    npm install babel-cli

See http://babeljs.io/docs/usage/cli/ for setup instructions.