### PR TITLE
More metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ If a message descriptor has a `description`, it'll be removed from the source af
 
 - **`moduleSourceName`**: The ES6 module source name of the React Intl package. Defaults to: `"react-intl"`, but can be changed to another name/path to React Intl.
 
+- **`fields`**: For specifying additional metadata fields and whether they're required. Takes an object with field names as key names, which specify whether they're required. `fields: { metadata: { required: true }, otherdata: {required: false} }`
+
 ### Via CLI
 
 ```sh

--- a/scripts/build-fixtures.js
+++ b/scripts/build-fixtures.js
@@ -15,6 +15,9 @@ const fixtures = [
     ['moduleSourceName', {
         moduleSourceName: 'react-i18n',
     }],
+    ['extractFieldConfig', {
+        fields: { metadata: { required: true}}
+    }],
 ];
 
 fixtures.forEach((fixture) => {

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const FUNCTION_NAMES = [
 const DESCRIPTOR_PROPS = {
     id: {required: true},
     description: {required:false},
-    defaultMessage: {required:true}
+    defaultMessage: {required:true},
 };
 
 const EXTRACTED_TAG = Symbol('ReactIntlExtracted');
@@ -117,7 +117,7 @@ export default function ({types: t}) {
         const {file, opts, reactIntl} = state;
 
         const missing_required = Object.keys(opts.fields)
-            .filter( key => opts.fields[key].required)
+            .filter( (key) => opts.fields[key].required)
             .reduce( (arr,key) => {
                 if(!messageDescriptor[key]){ arr.push( key ); }
                 return arr;

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ export default function ({types: t}) {
         return propPaths.reduce((hash, [keyPath, valuePath]) => {
             let key = getMessageDescriptorKey(keyPath);
 
-            if (Object.keys(fields).includes(key)) {
+            if (Object.keys(fields).indexOf(key) > -1) {
                 hash[key] = valuePath;
             }
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,9 @@ const FUNCTION_NAMES = [
 ];
 
 const DESCRIPTOR_PROPS = {
-	'id': { required: true},
-	'description': {required:false},
-	'defaultMessage': {required:true}
+    id: {required: true},
+    description: {required:false},
+    defaultMessage: {required:true}
 };
 
 const EXTRACTED_TAG = Symbol('ReactIntlExtracted');
@@ -113,21 +113,21 @@ export default function ({types: t}) {
     }
 
     function storeMessage(messageDescriptor, path, state) {
-		const {id, description, defaultMessage} = messageDescriptor;
+        const {id, description, defaultMessage} = messageDescriptor;
         const {file, opts, reactIntl} = state;
 
-		const missing_required = Object.keys(opts.fields)
-			.filter( key => opts.fields[key].required)
-			.reduce( (arr,key) => {
-				if(!messageDescriptor[key]){ arr.push( key ); }
-				return arr;
-			}, []);
+        const missing_required = Object.keys(opts.fields)
+            .filter( key => opts.fields[key].required)
+            .reduce( (arr,key) => {
+                if(!messageDescriptor[key]){ arr.push( key ); }
+                return arr;
+            }, []);
 
-		if(missing_required.length){
-			throw path.buildCodeFrameError(
-				'[React Intl] Message must have the following fields:' + missing_required.join(', ')
-			);
-		}
+        if(missing_required.length){
+            throw path.buildCodeFrameError(
+                '[React Intl] Message must have the following fields:' + missing_required.join(', ')
+            );
+        }
 
         if (reactIntl.messages.has(id)) {
             let existing = reactIntl.messages.get(id);
@@ -173,10 +173,10 @@ export default function ({types: t}) {
         visitor: {
             Program: {
                 enter(path, state) {
-					state.opts.fields = state.opts.fields || {};
-					const fields = state.opts.fields;
-					Object.assign(fields,DESCRIPTOR_PROPS);
-					fields.description.required = !!state.opts.enforceDescriptions;
+                    state.opts.fields = state.opts.fields || {};
+                    const fields = state.opts.fields;
+                    Object.assign(fields,DESCRIPTOR_PROPS);
+                    fields.description.required = !!state.opts.enforceDescriptions;
                     state.reactIntl = {
                         messages: new Map(),
                     };
@@ -239,7 +239,7 @@ export default function ({types: t}) {
                             attr.get('name'),
                             attr.get('value'),
                         ]),
-						opts.fields
+                        opts.fields
                     );
 
                     // In order for a default message to be extracted when
@@ -302,7 +302,7 @@ export default function ({types: t}) {
                             prop.get('key'),
                             prop.get('value'),
                         ]),
-						state.opts.fields
+                        state.opts.fields
                     );
 
                     // Evaluate the Message Descriptor values, then store it.

--- a/test/fixtures/extractFieldConfig/actual.js
+++ b/test/fixtures/extractFieldConfig/actual.js
@@ -1,0 +1,14 @@
+import React, {Component} from 'react';
+import {FormattedMessage} from 'react-intl';
+
+export default class Foo extends Component {
+    render() {
+        return (
+            <FormattedMessage
+                id='foo.bar.baz'
+                metadata='metadata content'
+                defaultMessage='Hello World!'
+            />
+        );
+    }
+}

--- a/test/fixtures/extractFieldConfig/expected.js
+++ b/test/fixtures/extractFieldConfig/expected.js
@@ -1,0 +1,46 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactIntl = require('react-intl');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Foo = function (_Component) {
+    _inherits(Foo, _Component);
+
+    function Foo() {
+        _classCallCheck(this, Foo);
+
+        return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+    }
+
+    _createClass(Foo, [{
+        key: 'render',
+        value: function render() {
+            return _react2.default.createElement(_reactIntl.FormattedMessage, {
+                id: 'foo.bar.baz',
+                metadata: 'metadata content',
+                defaultMessage: 'Hello World!'
+            });
+        }
+    }]);
+
+    return Foo;
+}(_react.Component);
+
+exports.default = Foo;

--- a/test/fixtures/extractFieldConfig/expected.json
+++ b/test/fixtures/extractFieldConfig/expected.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "foo.bar.baz",
+    "metadata": "metadata content",
+    "defaultMessage": "Hello World!"
+  }
+]

--- a/test/index.js
+++ b/test/index.js
@@ -162,11 +162,6 @@ describe('options', () => {
             assert(/Message must have the following fields/.test(e.message));
             assert(/metadata/.test(e.message));
         }
-
-        // Check message output
-        const expectedMessages = require(path.join(fixtureDir, 'expected.json'));
-        const actualMessages = require(path.join(fixtureDir, 'actual.json'));
-        assert.deepEqual(actualMessages, expectedMessages);
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -168,8 +168,6 @@ describe('options', () => {
         const actualMessages = require(path.join(fixtureDir, 'actual.json'));
         assert.deepEqual(actualMessages, expectedMessages);
     });
-
-	//todo test extracted info
 });
 
 describe('errors', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -130,6 +130,25 @@ describe('options', () => {
         assert.deepEqual(actualMessages, expectedMessages);
     });
 
+    it('respects field config, extracts data', () => {
+        const fixtureDir = path.join(fixturesDir, 'extractFieldConfig');
+
+        try {
+            transform(path.join(fixtureDir, 'actual.js'), {
+                fields: { metadata: { required: true}},
+            });
+            assert(true);
+        } catch (e) {
+            console.error(e);
+            assert(false);
+        }
+
+        // Check message output
+        const expectedMessages = require(path.join(fixtureDir, 'expected.json'));
+        const actualMessages = require(path.join(fixtureDir, 'actual.json'));
+        assert.deepEqual(actualMessages, expectedMessages);
+    });
+
     it('enforces field config required setting', () => {
         const fixtureDir = path.join(fixturesDir, 'extractSourceLocation');
 

--- a/test/index.js
+++ b/test/index.js
@@ -129,6 +129,28 @@ describe('options', () => {
         const actualMessages = require(path.join(fixtureDir, 'actual.json'));
         assert.deepEqual(actualMessages, expectedMessages);
     });
+
+    it('enforces field config required setting', () => {
+        const fixtureDir = path.join(fixturesDir, 'extractSourceLocation');
+
+        try {
+            transform(path.join(fixtureDir, 'actual.js'), {
+                fields: { metadata: { required: true}},
+            });
+            assert(false);
+        } catch (e) {
+            assert(e);
+            assert(/Message must have the following fields/.test(e.message));
+            assert(/metadata/.test(e.message));
+        }
+
+        // Check message output
+        const expectedMessages = require(path.join(fixtureDir, 'expected.json'));
+        const actualMessages = require(path.join(fixtureDir, 'actual.json'));
+        assert.deepEqual(actualMessages, expectedMessages);
+    });
+
+	//todo test extracted info
 });
 
 describe('errors', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,7 @@ const skipTests = [
     'moduleSourceName',
     'icuSyntax',
     'removeDescriptions',
+    'extractFieldConfig',
 ];
 
 const fixturesDir = path.join(__dirname, 'fixtures');

--- a/test/index.js
+++ b/test/index.js
@@ -39,9 +39,9 @@ describe('emit asserts for: ', () => {
             assert.equal(trim(actual), trim(expected));
 
             // Check message output
-            const expectedMessages = fs.readFileSync(path.join(fixtureDir, 'expected.json'));
-            const actualMessages = fs.readFileSync(path.join(fixtureDir, 'actual.json'));
-            assert.equal(trim(actualMessages), trim(expectedMessages));
+            const expectedMessages = require(path.join(fixtureDir, 'expected.json'));
+            const actualMessages = require(path.join(fixtureDir, 'actual.json'));
+            assert.deepEqual(actualMessages, expectedMessages);
         });
     });
 });
@@ -57,7 +57,8 @@ describe('options', () => {
             assert(false);
         } catch (e) {
             assert(e);
-            assert(/Message must have a `description`/.test(e.message));
+            assert(/Message must have the following fields/.test(e.message));
+            assert(/description/.test(e.message));
         }
     });
 
@@ -105,9 +106,9 @@ describe('options', () => {
         }
 
         // Check message output
-        const expectedMessages = fs.readFileSync(path.join(fixtureDir, 'expected.json'));
-        const actualMessages = fs.readFileSync(path.join(fixtureDir, 'actual.json'));
-        assert.equal(trim(actualMessages), trim(expectedMessages));
+        const expectedMessages = require(path.join(fixtureDir, 'expected.json'));
+        const actualMessages = require(path.join(fixtureDir, 'actual.json'));
+        assert.deepEqual(actualMessages, expectedMessages);
     });
 
     it('respects extractSourceLocation', () => {
@@ -124,9 +125,9 @@ describe('options', () => {
         }
 
         // Check message output
-        const expectedMessages = fs.readFileSync(path.join(fixtureDir, 'expected.json'));
-        const actualMessages = fs.readFileSync(path.join(fixtureDir, 'actual.json'));
-        assert.equal(trim(actualMessages), trim(expectedMessages));
+        const expectedMessages = require(path.join(fixtureDir, 'expected.json'));
+        const actualMessages = require(path.join(fixtureDir, 'actual.json'));
+        assert.deepEqual(actualMessages, expectedMessages);
     });
 });
 


### PR DESCRIPTION
addresses https://github.com/yahoo/babel-plugin-react-intl/issues/80

adds ability to configure additional metadata fields and whether they're required. 

**`fields`**: For specifying additional metadata fields and whether they're required. Takes an object with field names as key names, which specify whether they're required. `fields: { metadata: { required: true }, otherdata: {required: false} }`