### PR TITLE
allow object passed to description prop

### DIFF
--- a/scripts/build-fixtures.js
+++ b/scripts/build-fixtures.js
@@ -15,6 +15,7 @@ const fixtures = [
     ['moduleSourceName', {
         moduleSourceName: 'react-i18n',
     }],
+	'descriptionsAsObjects'
 ];
 
 fixtures.forEach((fixture) => {

--- a/scripts/build-fixtures.js
+++ b/scripts/build-fixtures.js
@@ -7,6 +7,7 @@ const baseDir = p.resolve(`${__dirname}/../test/fixtures`);
 
 const fixtures = [
     'defineMessages',
+    'descriptionsAsObjects',
     ['extractSourceLocation', {
         extractSourceLocation: true,
     }],
@@ -15,7 +16,6 @@ const fixtures = [
     ['moduleSourceName', {
         moduleSourceName: 'react-i18n',
     }],
-    'descriptionsAsObjects'
 ];
 
 fixtures.forEach((fixture) => {

--- a/scripts/build-fixtures.js
+++ b/scripts/build-fixtures.js
@@ -15,7 +15,7 @@ const fixtures = [
     ['moduleSourceName', {
         moduleSourceName: 'react-i18n',
     }],
-	'descriptionsAsObjects'
+    'descriptionsAsObjects'
 ];
 
 fixtures.forEach((fixture) => {

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ export default function ({types: t}) {
         // Always trim the Message Descriptor values.
         const descriptorValue = evaluatePath(path);
 
-        if( typeof descriptorValue === 'string' ){
+        if(typeof descriptorValue === 'string'){
             return descriptorValue.trim();
         }
         return descriptorValue;

--- a/src/index.js
+++ b/src/index.js
@@ -52,10 +52,10 @@ export default function ({types: t}) {
         }
 
         // Always trim the Message Descriptor values.
-        let descriptorValue = evaluatePath(path);
+        const descriptorValue = evaluatePath(path);
 
         if( typeof descriptorValue === 'string' ){
-            descriptorValue = descriptorValue.trim();
+            return descriptorValue.trim();
         }
         return descriptorValue;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,12 @@ export default function ({types: t}) {
         }
 
         // Always trim the Message Descriptor values.
-        return evaluatePath(path).trim();
+		let descriptorValue = evaluatePath(path);
+
+		if( typeof descriptorValue === 'string' ){
+			descriptorValue = descriptorValue.trim();
+		}
+        return descriptorValue;
     }
 
     function getICUMessageValue(messagePath, {isJSXSource = false} = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -52,11 +52,11 @@ export default function ({types: t}) {
         }
 
         // Always trim the Message Descriptor values.
-		let descriptorValue = evaluatePath(path);
+        let descriptorValue = evaluatePath(path);
 
-		if( typeof descriptorValue === 'string' ){
-			descriptorValue = descriptorValue.trim();
-		}
+        if( typeof descriptorValue === 'string' ){
+            descriptorValue = descriptorValue.trim();
+        }
         return descriptorValue;
     }
 

--- a/test/fixtures/descriptionsAsObjects/actual.js
+++ b/test/fixtures/descriptionsAsObjects/actual.js
@@ -1,0 +1,14 @@
+import React, {Component} from 'react';
+import {FormattedMessage} from 'react-intl';
+
+export default class Foo extends Component {
+    render() {
+        return (
+            <FormattedMessage
+                id='foo.bar.baz'
+                defaultMessage='Hello World!'
+                description={{ text:'The default message.', metadata:'metadata content'}}
+            />
+        );
+    }
+}

--- a/test/fixtures/descriptionsAsObjects/expected.js
+++ b/test/fixtures/descriptionsAsObjects/expected.js
@@ -1,0 +1,45 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactIntl = require('react-intl');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Foo = function (_Component) {
+    _inherits(Foo, _Component);
+
+    function Foo() {
+        _classCallCheck(this, Foo);
+
+        return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+    }
+
+    _createClass(Foo, [{
+        key: 'render',
+        value: function render() {
+            return _react2.default.createElement(_reactIntl.FormattedMessage, {
+                id: 'foo.bar.baz',
+                defaultMessage: 'Hello World!'
+            });
+        }
+    }]);
+
+    return Foo;
+}(_react.Component);
+
+exports.default = Foo;

--- a/test/fixtures/descriptionsAsObjects/expected.json
+++ b/test/fixtures/descriptionsAsObjects/expected.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "foo.bar.baz",
+    "description": {
+      "text": "The default message.",
+      "metadata": "metadata content"
+    },
+    "defaultMessage": "Hello World!"
+  }
+]


### PR DESCRIPTION
Follow up to https://github.com/yahoo/babel-plugin-react-intl/pull/85#issuecomment-268890574

Allows objects to be passed to the `description` prop.

Only code change required was to check the description type before `.trim()`

Added test to verify this works. 