### PR TITLE
fix(index): Remove the optimization such that the code extracts twice.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -307,21 +307,6 @@ export default function ({types: t}) {
                     // Evaluate the Message Descriptor values, then store it.
                     descriptor = evaluateMessageDescriptor(descriptor);
                     storeMessage(descriptor, messageObj, state);
-
-                    // Remove description since it's not used at runtime.
-                    messageObj.replaceWith(t.objectExpression([
-                        t.objectProperty(
-                            t.stringLiteral('id'),
-                            t.stringLiteral(descriptor.id)
-                        ),
-                        t.objectProperty(
-                            t.stringLiteral('defaultMessage'),
-                            t.stringLiteral(descriptor.defaultMessage)
-                        ),
-                    ]));
-
-                    // Tag the AST node so we don't try to extract it twice.
-                    tagAsExtracted(messageObj);
                 }
 
                 if (referencesImport(callee, moduleSourceName, FUNCTION_NAMES)) {


### PR DESCRIPTION
Attempts not to fix, but enlighten… This code is much too complicated for me to understand at face value.

Addresses: https://github.com/yahoo/babel-plugin-react-intl/issues/92

```
const messages = defineMessages({
  test: {
    defaultMessage: 'Test',
    description: 'Test',
    id: 'test',
  },
});
```

```
let descriptors = [...reactIntl.messages.values()];
file.metadata['react-intl'] = {messages: descriptors};

console.log(opts.messagesDir, descriptors);
```

Current:

```
undefined [ { id: 'test', description: 'Test', defaultMessage: 'Test' } ]
./messages []
undefined []
./messages []
```

After:

```
undefined [ { id: 'test', description: 'Test', defaultMessage: 'Test' } ]
./messages [ { id: 'test', description: 'Test', defaultMessage: 'Test' } ]
undefined []
./messages []
```

It looks like the `writeFileSync` only will be fired once `opts.messagesDir && descriptors.length > 0` succeeds. This will only succeed in the second run through. However, it probably doesn't get to the second run through if it has already been flagged as extracted.