### PR TITLE
Hoist state to file level

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,6 @@ If a message descriptor has a `description`, it'll be removed from the source af
 
 - **`moduleSourceName`**: The ES6 module source name of the React Intl package. Defaults to: `"react-intl"`, but can be changed to another name/path to React Intl.
 
-### Via CLI
-
-```sh
-$ babel --plugins react-intl script.js
-```
-
 ### Via Node API
 
 The extract message descriptors are available via the `metadata` property on the object returned from Babel's `transform()` API:


### PR DESCRIPTION
This fixes issues without writing the extracted messages out to the filesystem when multiple instances of the plugin are being applied.

This also removes the CLI usage docs which say to use `--plugins` option because this is not useful for this plugin since it needs to be configured via `.babelrc` or use via Babel's API.

Fixes #92