### PR TITLE
Add postinstall to enable npm install from git repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "babel-runtime": "^6.2.0",
     "intl-messageformat-parser": "^1.2.0",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "postinstall-build": "^3.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.1.18",
@@ -35,6 +36,7 @@
     "test": "cross-env NODE_ENV=test mocha --compilers js:babel-register",
     "build": "babel src/ --out-dir lib/",
     "build:fixtures": "babel-node ./scripts/build-fixtures.js",
+    "postinstall": "postinstall-build lib",
     "preversion": "npm run lint && npm run clean && npm run build",
     "prepublish": "npm run clean && npm run build"
   },


### PR DESCRIPTION
Using [postinstall-build](https://github.com/exogen/postinstall-build) which is a helper for conditionally building an npm package on `postinstall`. It checks for the existence of a `/lib` folder (which would be the case if installing from npm). Seems to fit the bill for #33 pretty well!