### PR TITLE
Allow extraction of messages without a defaultMessage

### DIFF
--- a/scripts/build-fixtures.js
+++ b/scripts/build-fixtures.js
@@ -1,41 +1,50 @@
 import * as p from 'path';
 import * as fs from 'fs';
-import {transformFileSync} from 'babel-core';
+import { transformFileSync } from 'babel-core';
 import plugin from '../src/index';
 
 const baseDir = p.resolve(`${__dirname}/../test/fixtures`);
 
 const fixtures = [
-    'defineMessages',
-    'descriptionsAsObjects',
-    ['extractSourceLocation', {
-        extractSourceLocation: true,
-    }],
-    'FormattedHTMLMessage',
-    'FormattedMessage',
-    ['moduleSourceName', {
-        moduleSourceName: 'react-i18n',
-    }],
+  'defineMessages',
+  'descriptionsAsObjects',
+  [
+    'extractSourceLocation',
+    {
+      extractSourceLocation: true,
+    },
+  ],
+  'FormattedHTMLMessage',
+  'FormattedMessage',
+  [
+    'moduleSourceName',
+    {
+      moduleSourceName: 'react-i18n',
+    },
+  ],
 ];
 
-fixtures.forEach((fixture) => {
-    let name = fixture;
-    let options = {};
-    if (Array.isArray(fixture)) {
-        [name, options] = fixture;
-    }
+fixtures.forEach(fixture => {
+  let name = fixture;
+  let options = {};
+  if (Array.isArray(fixture)) {
+    [name, options] = fixture;
+  }
 
-    let {code, metadata} = transformFileSync(`${baseDir}/${name}/actual.js`, {
-        plugins: [
-            [plugin, {
-                ...options,
-                messagesDir: false,
-            }],
-        ],
-    });
+  let { code, metadata } = transformFileSync(`${baseDir}/${name}/actual.js`, {
+    plugins: [
+      [
+        plugin,
+        {
+          ...options,
+          messagesDir: false,
+        },
+      ],
+    ],
+  });
 
-    let messages = JSON.stringify(metadata['react-intl'].messages, null, 2);
+  let messages = JSON.stringify(metadata['react-intl'].messages, null, 2);
 
-    fs.writeFileSync(`${baseDir}/${name}/expected.js`, `${code}\n`);
-    fs.writeFileSync(`${baseDir}/${name}/expected.json`, `${messages}\n`);
+  fs.writeFileSync(`${baseDir}/${name}/expected.js`, `${code}\n`);
+  fs.writeFileSync(`${baseDir}/${name}/expected.json`, `${messages}\n`);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -5,340 +5,341 @@
  */
 
 import * as p from 'path';
-import {writeFileSync} from 'fs';
-import {sync as mkdirpSync} from 'mkdirp';
+import { writeFileSync } from 'fs';
+import { sync as mkdirpSync } from 'mkdirp';
 import printICUMessage from './print-icu-message';
 
-const COMPONENT_NAMES = [
-    'FormattedMessage',
-    'FormattedHTMLMessage',
-];
+const COMPONENT_NAMES = ['FormattedMessage', 'FormattedHTMLMessage'];
 
-const FUNCTION_NAMES = [
-    'defineMessages',
-];
+const FUNCTION_NAMES = ['defineMessages'];
 
 const DESCRIPTOR_PROPS = new Set(['id', 'description', 'defaultMessage']);
 
 const EXTRACTED = Symbol('ReactIntlExtracted');
-const MESSAGES  = Symbol('ReactIntlMessages');
+const MESSAGES = Symbol('ReactIntlMessages');
 
-export default function ({types: t}) {
-    function getModuleSourceName(opts) {
-        return opts.moduleSourceName || 'react-intl';
+export default function({ types: t }) {
+  function getModuleSourceName(opts) {
+    return opts.moduleSourceName || 'react-intl';
+  }
+
+  function evaluatePath(path) {
+    const evaluated = path.evaluate();
+    if (evaluated.confident) {
+      return evaluated.value;
     }
 
-    function evaluatePath(path) {
-        const evaluated = path.evaluate();
-        if (evaluated.confident) {
-            return evaluated.value;
-        }
+    throw path.buildCodeFrameError(
+      '[React Intl] Messages must be statically evaluate-able for extraction.',
+    );
+  }
 
-        throw path.buildCodeFrameError(
-            '[React Intl] Messages must be statically evaluate-able for extraction.'
+  function getMessageDescriptorKey(path) {
+    if (path.isIdentifier() || path.isJSXIdentifier()) {
+      return path.node.name;
+    }
+
+    return evaluatePath(path);
+  }
+
+  function getMessageDescriptorValue(path) {
+    if (path.isJSXExpressionContainer()) {
+      path = path.get('expression');
+    }
+
+    // Always trim the Message Descriptor values.
+    const descriptorValue = evaluatePath(path);
+
+    if (typeof descriptorValue === 'string') {
+      return descriptorValue.trim();
+    }
+
+    return descriptorValue;
+  }
+
+  function getICUMessageValue(messagePath, { isJSXSource = false } = {}) {
+    const message = getMessageDescriptorValue(messagePath);
+
+    try {
+      return printICUMessage(message);
+    } catch (parseError) {
+      if (
+        isJSXSource &&
+        messagePath.isLiteral() &&
+        message.indexOf('\\\\') >= 0
+      ) {
+        throw messagePath.buildCodeFrameError(
+          '[React Intl] Message failed to parse. ' +
+            'It looks like `\\`s were used for escaping, ' +
+            "this won't work with JSX string literals. " +
+            'Wrap with `{}`. ' +
+            'See: http://facebook.github.io/react/docs/jsx-gotchas.html',
         );
+      }
+
+      throw messagePath.buildCodeFrameError(
+        '[React Intl] Message failed to parse. ' +
+          'See: http://formatjs.io/guides/message-syntax/' +
+          `\n${parseError}`,
+      );
+    }
+  }
+
+  function createMessageDescriptor(propPaths) {
+    return propPaths.reduce((hash, [keyPath, valuePath]) => {
+      const key = getMessageDescriptorKey(keyPath);
+
+      if (DESCRIPTOR_PROPS.has(key)) {
+        hash[key] = valuePath;
+      }
+
+      return hash;
+    }, {});
+  }
+
+  function evaluateMessageDescriptor(
+    { ...descriptor },
+    { isJSXSource = false } = {},
+  ) {
+    Object.keys(descriptor).forEach(key => {
+      const valuePath = descriptor[key];
+
+      if (key === 'defaultMessage') {
+        descriptor[key] = getICUMessageValue(valuePath, { isJSXSource });
+      } else {
+        descriptor[key] = getMessageDescriptorValue(valuePath);
+      }
+    });
+
+    return descriptor;
+  }
+
+  function storeMessage({ id, description, defaultMessage }, path, state) {
+    const { file, opts } = state;
+
+    if (opts.allowEmptyDefaultMessages) {
+      if (!id) {
+        throw path.buildCodeFrameError(
+          '[React Intl] Message Descriptors require an `id`.',
+        );
+      }
+    } else if (!(id && defaultMessage)) {
+      throw path.buildCodeFrameError(
+        '[React Intl] Message Descriptors require an `id` and `defaultMessage`.',
+      );
     }
 
-    function getMessageDescriptorKey(path) {
-        if (path.isIdentifier() || path.isJSXIdentifier()) {
-            return path.node.name;
-        }
+    const messages = file.get(MESSAGES);
+    if (messages.has(id)) {
+      const existing = messages.get(id);
 
-        return evaluatePath(path);
+      if (
+        description !== existing.description ||
+        defaultMessage !== existing.defaultMessage
+      ) {
+        throw path.buildCodeFrameError(
+          `[React Intl] Duplicate message id: "${id}", ` +
+            'but the `description` and/or `defaultMessage` are different.',
+        );
+      }
     }
 
-    function getMessageDescriptorValue(path) {
-        if (path.isJSXExpressionContainer()) {
-            path = path.get('expression');
-        }
-
-        // Always trim the Message Descriptor values.
-        const descriptorValue = evaluatePath(path);
-
-        if (typeof descriptorValue === 'string') {
-            return descriptorValue.trim();
-        }
-
-        return descriptorValue;
+    if (opts.enforceDescriptions) {
+      if (
+        !description ||
+        (typeof description === 'object' && Object.keys(description).length < 1)
+      ) {
+        throw path.buildCodeFrameError(
+          '[React Intl] Message must have a `description`.',
+        );
+      }
     }
 
-    function getICUMessageValue(messagePath, {isJSXSource = false} = {}) {
-        const message = getMessageDescriptorValue(messagePath);
+    let loc;
+    if (opts.extractSourceLocation) {
+      loc = {
+        file: p.relative(process.cwd(), file.opts.filename),
+        ...path.node.loc,
+      };
+    }
 
-        try {
-            return printICUMessage(message);
-        } catch (parseError) {
-            if (isJSXSource &&
-                messagePath.isLiteral() &&
-                message.indexOf('\\\\') >= 0) {
+    if (opts.allowEmptyDefaultMessages && !defaultMessage) {
+      messages.set(id, { id, description, ...loc });
+    } else {
+      messages.set(id, { id, description, defaultMessage, ...loc });
+    }
+  }
 
-                throw messagePath.buildCodeFrameError(
-                    '[React Intl] Message failed to parse. ' +
-                    'It looks like `\\`s were used for escaping, ' +
-                    'this won\'t work with JSX string literals. ' +
-                    'Wrap with `{}`. ' +
-                    'See: http://facebook.github.io/react/docs/jsx-gotchas.html'
-                );
-            }
+  function referencesImport(path, mod, importedNames) {
+    if (!(path.isIdentifier() || path.isJSXIdentifier())) {
+      return false;
+    }
 
-            throw messagePath.buildCodeFrameError(
-                '[React Intl] Message failed to parse. ' +
-                'See: http://formatjs.io/guides/message-syntax/' +
-                `\n${parseError}`
+    return importedNames.some(name => path.referencesImport(mod, name));
+  }
+
+  function tagAsExtracted(path) {
+    path.node[EXTRACTED] = true;
+  }
+
+  function wasExtracted(path) {
+    return !!path.node[EXTRACTED];
+  }
+
+  return {
+    pre(file) {
+      if (!file.has(MESSAGES)) {
+        file.set(MESSAGES, new Map());
+      }
+    },
+
+    post(file) {
+      const { opts } = this;
+      const { basename, filename } = file.opts;
+
+      const messages = file.get(MESSAGES);
+      const descriptors = [...messages.values()];
+      file.metadata['react-intl'] = { messages: descriptors };
+
+      if (opts.messagesDir && descriptors.length > 0) {
+        // Make sure the relative path is "absolute" before
+        // joining it with the `messagesDir`.
+        const relativePath = p.join(p.sep, p.relative(process.cwd(), filename));
+
+        const messagesFilename = p.join(
+          opts.messagesDir,
+          p.dirname(relativePath),
+          basename + '.json',
+        );
+
+        const messagesFile = JSON.stringify(descriptors, null, 2);
+
+        mkdirpSync(p.dirname(messagesFilename));
+        writeFileSync(messagesFilename, messagesFile);
+      }
+    },
+
+    visitor: {
+      JSXOpeningElement(path, state) {
+        if (wasExtracted(path)) {
+          return;
+        }
+
+        const { file, opts } = state;
+        const moduleSourceName = getModuleSourceName(opts);
+        const name = path.get('name');
+
+        if (name.referencesImport(moduleSourceName, 'FormattedPlural')) {
+          file.log.warn(
+            `[React Intl] Line ${path.node.loc.start.line}: ` +
+              'Default messages are not extracted from ' +
+              '<FormattedPlural>, use <FormattedMessage> instead.',
+          );
+
+          return;
+        }
+
+        if (referencesImport(name, moduleSourceName, COMPONENT_NAMES)) {
+          const attributes = path
+            .get('attributes')
+            .filter(attr => attr.isJSXAttribute());
+
+          let descriptor = createMessageDescriptor(
+            attributes.map(attr => [attr.get('name'), attr.get('value')]),
+          );
+
+          // In order for a default message to be extracted when
+          // declaring a JSX element, it must be done with standard
+          // `key=value` attributes. But it's completely valid to
+          // write `<FormattedMessage {...descriptor} />` or
+          // `<FormattedMessage id={dynamicId} />`, because it will be
+          // skipped here and extracted elsewhere. The descriptor will
+          // be extracted only if a `defaultMessage` prop exists.
+          if (descriptor.defaultMessage || opts.allowEmptyDefaultMessages) {
+            // Evaluate the Message Descriptor values in a JSX
+            // context, then store it.
+            descriptor = evaluateMessageDescriptor(descriptor, {
+              isJSXSource: true,
+            });
+
+            storeMessage(descriptor, path, state);
+
+            // Remove description since it's not used at runtime.
+            attributes.some(attr => {
+              const ketPath = attr.get('name');
+              if (getMessageDescriptorKey(ketPath) === 'description') {
+                attr.remove();
+                return true;
+              }
+            });
+
+            // Tag the AST node so we don't try to extract it twice.
+            tagAsExtracted(path);
+          }
+        }
+      },
+
+      CallExpression(path, state) {
+        const moduleSourceName = getModuleSourceName(state.opts);
+        const callee = path.get('callee');
+
+        function assertObjectExpression(node) {
+          if (!(node && node.isObjectExpression())) {
+            throw path.buildCodeFrameError(
+              `[React Intl] \`${callee.node.name}()\` must be ` +
+                'called with an object expression with values ' +
+                'that are React Intl Message Descriptors, also ' +
+                'defined as object expressions.',
             );
-        }
-    }
-
-    function createMessageDescriptor(propPaths) {
-        return propPaths.reduce((hash, [keyPath, valuePath]) => {
-            const key = getMessageDescriptorKey(keyPath);
-
-            if (DESCRIPTOR_PROPS.has(key)) {
-                hash[key] = valuePath;
-            }
-
-            return hash;
-        }, {});
-    }
-
-    function evaluateMessageDescriptor({...descriptor}, {isJSXSource = false} = {}) {
-        Object.keys(descriptor).forEach((key) => {
-            const valuePath = descriptor[key];
-
-            if (key === 'defaultMessage') {
-                descriptor[key] = getICUMessageValue(valuePath, {isJSXSource});
-            } else {
-                descriptor[key] = getMessageDescriptorValue(valuePath);
-            }
-        });
-
-        return descriptor;
-    }
-
-    function storeMessage({id, description, defaultMessage}, path, state) {
-        const {file, opts} = state;
-
-        if (opts.allowEmptyDefaultMessages) {
-            if (!id) {
-                throw path.buildCodeFrameError('[React Intl] Message Descriptors require an `id`.');
-            } else if (!defaultMessage) {
-              defaultMessage = id;
-            }
-        } else if (!(id && defaultMessage)) {
-            throw path.buildCodeFrameError('[React Intl] Message Descriptors require an `id` and `defaultMessage`.');
+          }
         }
 
-        const messages = file.get(MESSAGES);
-        if (messages.has(id)) {
-            const existing = messages.get(id);
+        function processMessageObject(messageObj) {
+          assertObjectExpression(messageObj);
 
-            if (description !== existing.description ||
-                defaultMessage !== existing.defaultMessage) {
+          if (wasExtracted(messageObj)) {
+            return;
+          }
 
-                throw path.buildCodeFrameError(
-                    `[React Intl] Duplicate message id: "${id}", ` +
-                    'but the `description` and/or `defaultMessage` are different.'
-                );
-            }
+          const properties = messageObj.get('properties');
+
+          let descriptor = createMessageDescriptor(
+            properties.map(prop => [prop.get('key'), prop.get('value')]),
+          );
+
+          // Evaluate the Message Descriptor values, then store it.
+          descriptor = evaluateMessageDescriptor(descriptor);
+          storeMessage(descriptor, messageObj, state);
+
+          // Remove description since it's not used at runtime.
+          messageObj.replaceWith(
+            t.objectExpression([
+              t.objectProperty(
+                t.stringLiteral('id'),
+                t.stringLiteral(descriptor.id),
+              ),
+              t.objectProperty(
+                t.stringLiteral('defaultMessage'),
+                t.stringLiteral(descriptor.defaultMessage),
+              ),
+            ]),
+          );
+
+          // Tag the AST node so we don't try to extract it twice.
+          tagAsExtracted(messageObj);
         }
 
-        if (opts.enforceDescriptions) {
-            if (
-                !description ||
-                (typeof description === 'object' && Object.keys(description).length < 1)
-            ) {
-                throw path.buildCodeFrameError(
-                    '[React Intl] Message must have a `description`.'
-                );
-            }
+        if (referencesImport(callee, moduleSourceName, FUNCTION_NAMES)) {
+          const messagesObj = path.get('arguments')[0];
+
+          assertObjectExpression(messagesObj);
+
+          messagesObj
+            .get('properties')
+            .map(prop => prop.get('value'))
+            .forEach(processMessageObject);
         }
-
-        let loc;
-        if (opts.extractSourceLocation) {
-            loc = {
-                file: p.relative(process.cwd(), file.opts.filename),
-                ...path.node.loc,
-            };
-        }
-
-        messages.set(id, {id, description, defaultMessage, ...loc});
-    }
-
-    function referencesImport(path, mod, importedNames) {
-        if (!(path.isIdentifier() || path.isJSXIdentifier())) {
-            return false;
-        }
-
-        return importedNames.some((name) => path.referencesImport(mod, name));
-    }
-
-    function tagAsExtracted(path) {
-        path.node[EXTRACTED] = true;
-    }
-
-    function wasExtracted(path) {
-        return !!path.node[EXTRACTED];
-    }
-
-    return {
-        pre(file) {
-            if (!file.has(MESSAGES)) {
-                file.set(MESSAGES, new Map());
-            }
-        },
-
-        post(file) {
-            const {opts} = this;
-            const {basename, filename} = file.opts;
-
-            const messages = file.get(MESSAGES);
-            const descriptors = [...messages.values()];
-            file.metadata['react-intl'] = {messages: descriptors};
-
-            if (opts.messagesDir && descriptors.length > 0) {
-                // Make sure the relative path is "absolute" before
-                // joining it with the `messagesDir`.
-                const relativePath = p.join(
-                    p.sep,
-                    p.relative(process.cwd(), filename)
-                );
-
-                const messagesFilename = p.join(
-                    opts.messagesDir,
-                    p.dirname(relativePath),
-                    basename + '.json'
-                );
-
-                const messagesFile = JSON.stringify(descriptors, null, 2);
-
-                mkdirpSync(p.dirname(messagesFilename));
-                writeFileSync(messagesFilename, messagesFile);
-            }
-        },
-
-        visitor: {
-            JSXOpeningElement(path, state) {
-                if (wasExtracted(path)) {
-                    return;
-                }
-
-                const {file, opts} = state;
-                const moduleSourceName = getModuleSourceName(opts);
-                const name = path.get('name');
-
-                if (name.referencesImport(moduleSourceName, 'FormattedPlural')) {
-                    file.log.warn(
-                        `[React Intl] Line ${path.node.loc.start.line}: ` +
-                        'Default messages are not extracted from ' +
-                        '<FormattedPlural>, use <FormattedMessage> instead.'
-                    );
-
-                    return;
-                }
-
-                if (referencesImport(name, moduleSourceName, COMPONENT_NAMES)) {
-                    const attributes = path.get('attributes')
-                        .filter((attr) => attr.isJSXAttribute());
-
-                    let descriptor = createMessageDescriptor(
-                        attributes.map((attr) => [
-                            attr.get('name'),
-                            attr.get('value'),
-                        ])
-                    );
-
-                    // In order for a default message to be extracted when
-                    // declaring a JSX element, it must be done with standard
-                    // `key=value` attributes. But it's completely valid to
-                    // write `<FormattedMessage {...descriptor} />` or
-                    // `<FormattedMessage id={dynamicId} />`, because it will be
-                    // skipped here and extracted elsewhere. The descriptor will
-                    // be extracted only if a `defaultMessage` prop exists.
-                    if (descriptor.defaultMessage || opts.allowEmptyDefaultMessages) {
-                        // Evaluate the Message Descriptor values in a JSX
-                        // context, then store it.
-                        descriptor = evaluateMessageDescriptor(descriptor, {
-                            isJSXSource: true,
-                        });
-
-                        storeMessage(descriptor, path, state);
-
-                        // Remove description since it's not used at runtime.
-                        attributes.some((attr) => {
-                            const ketPath = attr.get('name');
-                            if (getMessageDescriptorKey(ketPath) === 'description') {
-                                attr.remove();
-                                return true;
-                            }
-                        });
-
-                        // Tag the AST node so we don't try to extract it twice.
-                        tagAsExtracted(path);
-                    }
-                }
-            },
-
-            CallExpression(path, state) {
-                const moduleSourceName = getModuleSourceName(state.opts);
-                const callee = path.get('callee');
-
-                function assertObjectExpression(node) {
-                    if (!(node && node.isObjectExpression())) {
-                        throw path.buildCodeFrameError(
-                            `[React Intl] \`${callee.node.name}()\` must be ` +
-                            'called with an object expression with values ' +
-                            'that are React Intl Message Descriptors, also ' +
-                            'defined as object expressions.'
-                        );
-                    }
-                }
-
-                function processMessageObject(messageObj) {
-                    assertObjectExpression(messageObj);
-
-                    if (wasExtracted(messageObj)) {
-                        return;
-                    }
-
-                    const properties = messageObj.get('properties');
-
-                    let descriptor = createMessageDescriptor(
-                        properties.map((prop) => [
-                            prop.get('key'),
-                            prop.get('value'),
-                        ])
-                    );
-
-                    // Evaluate the Message Descriptor values, then store it.
-                    descriptor = evaluateMessageDescriptor(descriptor);
-                    storeMessage(descriptor, messageObj, state);
-
-                    // Remove description since it's not used at runtime.
-                    messageObj.replaceWith(t.objectExpression([
-                        t.objectProperty(
-                            t.stringLiteral('id'),
-                            t.stringLiteral(descriptor.id)
-                        ),
-                        t.objectProperty(
-                            t.stringLiteral('defaultMessage'),
-                            t.stringLiteral(descriptor.defaultMessage)
-                        ),
-                    ]));
-
-                    // Tag the AST node so we don't try to extract it twice.
-                    tagAsExtracted(messageObj);
-                }
-
-                if (referencesImport(callee, moduleSourceName, FUNCTION_NAMES)) {
-                    const messagesObj = path.get('arguments')[0];
-
-                    assertObjectExpression(messagesObj);
-
-                    messagesObj.get('properties')
-                        .map((prop) => prop.get('value'))
-                        .forEach(processMessageObject);
-                }
-            },
-        },
-    };
+      },
+    },
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -118,10 +118,14 @@ export default function ({types: t}) {
     function storeMessage({id, description, defaultMessage}, path, state) {
         const {file, opts} = state;
 
-        if (!(id && defaultMessage)) {
-            throw path.buildCodeFrameError(
-                '[React Intl] Message Descriptors require an `id` and `defaultMessage`.'
-            );
+        if (opts.allowEmptyDefaultMessages) {
+          if (!id) {
+              throw path.buildCodeFrameError('[React Intl] Message Descriptors require an `id`.');
+          } else if (!defaultMessage) {
+            defaultMessage = id;
+          }
+        } else if (!(id && defaultMessage)) {
+            throw path.buildCodeFrameError('[React Intl] Message Descriptors require an `id` and `defaultMessage`.');
         }
 
         const messages = file.get(MESSAGES);
@@ -250,7 +254,7 @@ export default function ({types: t}) {
                     // `<FormattedMessage id={dynamicId} />`, because it will be
                     // skipped here and extracted elsewhere. The descriptor will
                     // be extracted only if a `defaultMessage` prop exists.
-                    if (descriptor.defaultMessage) {
+                    if (descriptor.defaultMessage || opts.allowEmptyDefaultMessages) {
                         // Evaluate the Message Descriptor values in a JSX
                         // context, then store it.
                         descriptor = evaluateMessageDescriptor(descriptor, {

--- a/src/index.js
+++ b/src/index.js
@@ -119,11 +119,11 @@ export default function ({types: t}) {
         const {file, opts} = state;
 
         if (opts.allowEmptyDefaultMessages) {
-          if (!id) {
-              throw path.buildCodeFrameError('[React Intl] Message Descriptors require an `id`.');
-          } else if (!defaultMessage) {
-            defaultMessage = id;
-          }
+            if (!id) {
+                throw path.buildCodeFrameError('[React Intl] Message Descriptors require an `id`.');
+            } else if (!defaultMessage) {
+              defaultMessage = id;
+            }
         } else if (!(id && defaultMessage)) {
             throw path.buildCodeFrameError('[React Intl] Message Descriptors require an `id` and `defaultMessage`.');
         }
@@ -254,7 +254,7 @@ export default function ({types: t}) {
                     // `<FormattedMessage id={dynamicId} />`, because it will be
                     // skipped here and extracted elsewhere. The descriptor will
                     // be extracted only if a `defaultMessage` prop exists.
-                    if (descriptor.defaultMessage || opts.allowEmptyDefaultMessages) {
+                    if (descriptor.defaultMessage || opts.allowEmptyDefaultMessages) {
                         // Evaluate the Message Descriptor values in a JSX
                         // context, then store it.
                         descriptor = evaluateMessageDescriptor(descriptor, {

--- a/src/print-icu-message.js
+++ b/src/print-icu-message.js
@@ -4,78 +4,78 @@
  * See the accompanying LICENSE file for terms.
  */
 
-import {parse} from 'intl-messageformat-parser';
+import { parse } from 'intl-messageformat-parser';
 
 const ESCAPED_CHARS = {
-    '\\' : '\\\\',
-    '\\#': '\\#',
-    '{'  : '\\{',
-    '}'  : '\\}',
+  '\\': '\\\\',
+  '\\#': '\\#',
+  '{': '\\{',
+  '}': '\\}',
 };
 
 const ESAPE_CHARS_REGEXP = /\\#|[{}\\]/g;
 
-export default function (message) {
-    let ast = parse(message);
-    return printICUMessage(ast);
+export default function(message) {
+  let ast = parse(message);
+  return printICUMessage(ast);
 }
 
 function printICUMessage(ast) {
-    let printedNodes = ast.elements.map((node) => {
-        if (node.type === 'messageTextElement') {
-            return printMessageTextASTNode(node);
-        }
+  let printedNodes = ast.elements.map(node => {
+    if (node.type === 'messageTextElement') {
+      return printMessageTextASTNode(node);
+    }
 
-        if (!node.format) {
-            return `{${node.id}}`;
-        }
+    if (!node.format) {
+      return `{${node.id}}`;
+    }
 
-        switch (getArgumentType(node.format)) {
-        case 'number':
-        case 'date':
-        case 'time':
-            return printSimpleFormatASTNode(node);
+    switch (getArgumentType(node.format)) {
+      case 'number':
+      case 'date':
+      case 'time':
+        return printSimpleFormatASTNode(node);
 
-        case 'plural':
-        case 'selectordinal':
-        case 'select':
-            return printOptionalFormatASTNode(node);
-        }
-    });
+      case 'plural':
+      case 'selectordinal':
+      case 'select':
+        return printOptionalFormatASTNode(node);
+    }
+  });
 
-    return printedNodes.join('');
+  return printedNodes.join('');
 }
 
 function getArgumentType(format) {
-    const {type, ordinal} = format;
+  const { type, ordinal } = format;
 
-    // Special-case ordinal plurals to use `selectordinal` instead of `plural`.
-    if (type === 'pluralFormat' && ordinal) {
-        return 'selectordinal';
-    }
+  // Special-case ordinal plurals to use `selectordinal` instead of `plural`.
+  if (type === 'pluralFormat' && ordinal) {
+    return 'selectordinal';
+  }
 
-    return type.replace(/Format$/, '').toLowerCase();
+  return type.replace(/Format$/, '').toLowerCase();
 }
 
-function printMessageTextASTNode({value}) {
-    return value.replace(ESAPE_CHARS_REGEXP, (char) => ESCAPED_CHARS[char]);
+function printMessageTextASTNode({ value }) {
+  return value.replace(ESAPE_CHARS_REGEXP, char => ESCAPED_CHARS[char]);
 }
 
-function printSimpleFormatASTNode({id, format}) {
-    let argumentType = getArgumentType(format);
-    let style = format.style ? `, ${format.style}` : '';
+function printSimpleFormatASTNode({ id, format }) {
+  let argumentType = getArgumentType(format);
+  let style = format.style ? `, ${format.style}` : '';
 
-    return `{${id}, ${argumentType}${style}}`;
+  return `{${id}, ${argumentType}${style}}`;
 }
 
-function printOptionalFormatASTNode({id, format}) {
-    let argumentType = getArgumentType(format);
-    let offset = format.offset ? `, offset:${format.offset}` : '';
+function printOptionalFormatASTNode({ id, format }) {
+  let argumentType = getArgumentType(format);
+  let offset = format.offset ? `, offset:${format.offset}` : '';
 
-    let options = format.options.map((option) => {
-        let optionValue = printICUMessage(option.value);
-        return ` ${option.selector} {${optionValue}}`;
-    });
+  let options = format.options.map(option => {
+    let optionValue = printICUMessage(option.value);
+    return ` ${option.selector} {${optionValue}}`;
+  });
 
-    return `{${id}, ${argumentType}${offset},${options.join('')}}`;
+  return `{${id}, ${argumentType}${offset},${options.join('')}}`;
 }


### PR DESCRIPTION
Addresses #43.

This adds a new option called `allowEmptyDefaultMessages`. When `true`, it stores all messages encountered and adds as `defaultMessage` the `id` of the message, which follows the current chain of priority, that ultimately falls back to the `id` of a message.

I'll add some documentation if this looks reasonable.