### PR TITLE
Fix Babel 7 compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,8 +185,9 @@ export default function ({types: t}) {
 
         post(file) {
             const {opts} = this;
-            const {basename, filename} = file.opts;
+            const {filename} = file.opts;
 
+            const basename = p.basename(filename, p.extname(filename));
             const messages = file.get(MESSAGES);
             const descriptors = [...messages.values()];
             file.metadata['react-intl'] = {messages: descriptors};


### PR DESCRIPTION
`basename` got removed: https://babeljs.io/blog/2017/03/01/upgrade-to-babel-7-for-tool-authors