### PR TITLE
New options: removeDefaultMessage and keepDescriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ If a message descriptor has a `description`, it'll be removed from the source af
 
 - **`moduleSourceName`**: The ES6 module source name of the React Intl package. Defaults to: `"react-intl"`, but can be changed to another name/path to React Intl.
 
+- **`keepDescriptions`**: When `true`, then `description` will not be removed from transformed code. Defaults to: `false`.
+
+- **`removeDefaultMessage`**: When `true`, then `defaultMessage` will be removed from transformed code. Defaults to: `false`.
+
 ### Via Node API
 
 The extract message descriptors are available via the `metadata` property on the object returned from Babel's `transform()` API:

--- a/scripts/build-fixtures.js
+++ b/scripts/build-fixtures.js
@@ -16,6 +16,13 @@ const fixtures = [
     ['moduleSourceName', {
         moduleSourceName: 'react-i18n',
     }],
+    ['keepDescriptions', {
+        enforceDescriptions: true,
+        keepDescriptions: true,
+    }],
+    ['removeDefaultMessage', {
+        removeDefaultMessage: true,
+    }],
 ];
 
 fixtures.forEach((fixture) => {

--- a/test/fixtures/keepDescriptions/actual.js
+++ b/test/fixtures/keepDescriptions/actual.js
@@ -1,0 +1,22 @@
+import React, {Component} from 'react';
+import {defineMessages, FormattedMessage} from 'react-intl';
+
+const messages = defineMessages({
+    foo: {
+        id: 'greeting-user',
+        description: 'Greeting the user',
+        defaultMessage: 'Hello, {name}',
+    },
+});
+
+export default class Foo extends Component {
+    render() {
+        return (
+            <FormattedMessage
+                id='greeting-world'
+                description='Greeting to the world'
+                defaultMessage='Hello World!'
+            />
+        );
+    }
+}

--- a/test/fixtures/keepDescriptions/expected.js
+++ b/test/fixtures/keepDescriptions/expected.js
@@ -1,0 +1,54 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactIntl = require('react-intl');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var messages = (0, _reactIntl.defineMessages)({
+    foo: {
+        'id': 'greeting-user',
+        'description': 'Greeting the user',
+        'defaultMessage': 'Hello, {name}'
+    }
+});
+
+var Foo = function (_Component) {
+    _inherits(Foo, _Component);
+
+    function Foo() {
+        _classCallCheck(this, Foo);
+
+        return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+    }
+
+    _createClass(Foo, [{
+        key: 'render',
+        value: function render() {
+            return _react2.default.createElement(_reactIntl.FormattedMessage, {
+                id: 'greeting-world',
+                description: 'Greeting to the world',
+                defaultMessage: 'Hello World!'
+            });
+        }
+    }]);
+
+    return Foo;
+}(_react.Component);
+
+exports.default = Foo;

--- a/test/fixtures/keepDescriptions/expected.json
+++ b/test/fixtures/keepDescriptions/expected.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "greeting-user",
+    "description": "Greeting the user",
+    "defaultMessage": "Hello, {name}"
+  },
+  {
+    "id": "greeting-world",
+    "description": "Greeting to the world",
+    "defaultMessage": "Hello World!"
+  }
+]

--- a/test/fixtures/removeDefaultMessage/actual.js
+++ b/test/fixtures/removeDefaultMessage/actual.js
@@ -1,0 +1,22 @@
+import React, {Component} from 'react';
+import {defineMessages, FormattedMessage} from 'react-intl';
+
+const messages = defineMessages({
+    foo: {
+        id: 'greeting-user',
+        description: 'Greeting the user',
+        defaultMessage: 'Hello, {name}',
+    },
+});
+
+export default class Foo extends Component {
+    render() {
+        return (
+            <FormattedMessage
+                id='greeting-world'
+                description='Greeting to the world'
+                defaultMessage='Hello World!'
+            />
+        );
+    }
+}

--- a/test/fixtures/removeDefaultMessage/expected.js
+++ b/test/fixtures/removeDefaultMessage/expected.js
@@ -1,0 +1,50 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactIntl = require('react-intl');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var messages = (0, _reactIntl.defineMessages)({
+    foo: {
+        'id': 'greeting-user'
+    }
+});
+
+var Foo = function (_Component) {
+    _inherits(Foo, _Component);
+
+    function Foo() {
+        _classCallCheck(this, Foo);
+
+        return _possibleConstructorReturn(this, (Foo.__proto__ || Object.getPrototypeOf(Foo)).apply(this, arguments));
+    }
+
+    _createClass(Foo, [{
+        key: 'render',
+        value: function render() {
+            return _react2.default.createElement(_reactIntl.FormattedMessage, {
+                id: 'greeting-world'
+            });
+        }
+    }]);
+
+    return Foo;
+}(_react.Component);
+
+exports.default = Foo;

--- a/test/fixtures/removeDefaultMessage/expected.json
+++ b/test/fixtures/removeDefaultMessage/expected.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "greeting-user",
+    "description": "Greeting the user",
+    "defaultMessage": "Hello, {name}"
+  },
+  {
+    "id": "greeting-world",
+    "description": "Greeting to the world",
+    "defaultMessage": "Hello World!"
+  }
+]

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,8 @@ const skipTests = [
     'moduleSourceName',
     'icuSyntax',
     'removeDescriptions',
+    'keepDescriptions',
+    'removeDefaultMessage',
 ];
 
 const fixturesDir = path.join(__dirname, 'fixtures');
@@ -81,6 +83,23 @@ describe('options', () => {
         try {
             transform(path.join(fixtureDir, 'actual.js'), {
                 enforceDescriptions: true,
+            }, {
+                multiplePasses: true,
+            });
+            assert(true);
+        } catch (e) {
+            console.error(e);
+            assert(false);
+        }
+    });
+
+    it('keep descriptions when plugin is applied more than once with keepDescriptions=true', () => {
+        const fixtureDir = path.join(fixturesDir, 'keepDescriptions');
+
+        try {
+            transform(path.join(fixtureDir, 'actual.js'), {
+                enforceDescriptions: true,
+                keepDescriptions: true,
             }, {
                 multiplePasses: true,
             });


### PR DESCRIPTION
New options:

- **`keepDescriptions`**: When `true`, then `description` will not be removed from transformed code. Defaults to: `false`.

- **`removeDefaultMessage`**: When `true`, then `defaultMessage` will be removed from transformed code. Defaults to: `false`.