### PR TITLE
Export messages by category and other options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -287,6 +287,7 @@ export default function ({types: t}) {
 
             CallExpression(path, state) {
                 const moduleSourceName = getModuleSourceName(state.opts);
+                const {extractInjectionApi} = state.opts;
                 const callee = path.get('callee');
 
                 function assertObjectExpression(node) {
@@ -346,6 +347,15 @@ export default function ({types: t}) {
                     messagesObj.get('properties')
                         .map((prop) => prop.get('value'))
                         .forEach(processMessageObject);
+                } else if (
+                    extractInjectionApi &&
+                    t.isMemberExpression(callee.node, { computed: false }) &&
+                    t.isIdentifier(callee.node.object, { name: 'intl' }) &&
+                    t.isIdentifier(callee.node.property, { name: 'formatMessage' })
+                ) {
+                    // parse intl.formatMessage calls
+                    const messagesObj = path.get('arguments')[0];
+                    processMessageObject(messagesObj);
                 }
             },
         },

--- a/src/index.js
+++ b/src/index.js
@@ -227,6 +227,7 @@ export default function ({types: t}) {
 
                 const {file, opts} = state;
                 const moduleSourceName = getModuleSourceName(opts);
+                const componentNames = opts.componentNames || COMPONENT_NAMES;
                 const name = path.get('name');
 
                 if (name.referencesImport(moduleSourceName, 'FormattedPlural')) {
@@ -239,7 +240,7 @@ export default function ({types: t}) {
                     return;
                 }
 
-                if (referencesImport(name, moduleSourceName, COMPONENT_NAMES)) {
+                if (referencesImport(name, moduleSourceName, componentNames)) {
                     const attributes = path.get('attributes')
                         .filter((attr) => attr.isJSXAttribute());
 

--- a/test/fixtures/componentNames/actual.js
+++ b/test/fixtures/componentNames/actual.js
@@ -1,0 +1,20 @@
+import React, {Component} from 'react';
+import DefaultMessage, {Message} from 'react-i18n';
+
+export default class Foo extends Component {
+    render() {
+        return (
+            <div>
+                <DefaultMessage
+                    id='foo.bar.baz'
+                    defaultMessage='Hello World!'
+                    description='The default message.'
+                />
+                <Message
+                    id='foo.bar'
+                    defaultMessage='Foo bar!'
+                />
+            </div>
+        );
+    }
+}

--- a/test/fixtures/componentNames/expected.json
+++ b/test/fixtures/componentNames/expected.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "foo.bar.baz",
+    "description": "The default message.",
+    "defaultMessage": "Hello World!"
+  },
+  {
+    "id": "foo.bar",
+    "defaultMessage": "Foo bar!"
+  }
+]

--- a/test/fixtures/enforceDefaultMessages/actual.js
+++ b/test/fixtures/enforceDefaultMessages/actual.js
@@ -1,0 +1,22 @@
+import React, {Component} from 'react';
+import {defineMessages, FormattedMessage} from 'react-intl';
+
+
+const msgs = defineMessages({
+    content: {
+        id: 'foo.bar.biff',
+    },
+});
+
+export default class Foo extends Component {
+    render() {
+        return (
+            <div>
+                {msgs}
+                <FormattedMessage
+                    id='foo.bar.baz'
+                />
+            </div>
+        );
+    }
+}

--- a/test/fixtures/extractInjectionApi/actual.js
+++ b/test/fixtures/extractInjectionApi/actual.js
@@ -1,0 +1,17 @@
+import React, {Component} from 'react';
+
+export default class Foo extends Component {
+    render() {
+        const {intl} = this.props;
+
+        return (
+            <div>
+                {intl.formatMessage({
+                    id: 'foo.bar.baz',
+                    defaultMessage: 'Hello World!',
+                    description: 'The default message.',
+                })}
+            </div>
+        );
+    }
+}

--- a/test/fixtures/extractInjectionApi/expected.json
+++ b/test/fixtures/extractInjectionApi/expected.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "foo.bar.baz",
+    "description": "The default message.",
+    "defaultMessage": "Hello World!"
+  }
+]

--- a/test/fixtures/messagesStructureCategory/.gitignore
+++ b/test/fixtures/messagesStructureCategory/.gitignore
@@ -1,0 +1,2 @@
+foo.json
+default.json

--- a/test/fixtures/messagesStructureCategory/actual.js
+++ b/test/fixtures/messagesStructureCategory/actual.js
@@ -1,0 +1,19 @@
+import React, {Component} from 'react';
+import {FormattedMessage} from 'react-intl';
+
+export default class Foo extends Component {
+    render() {
+        return (
+            <div>
+                <FormattedMessage
+                    id='hello_world'
+                    defaultMessage='Hello World!'
+                />
+                <FormattedMessage
+                    id='foo.bar.baz'
+                    defaultMessage='foo bar baz'
+                />
+            </div>
+        );
+    }
+}

--- a/test/fixtures/messagesStructureCategory/actual2.js
+++ b/test/fixtures/messagesStructureCategory/actual2.js
@@ -1,0 +1,19 @@
+import React, {Component} from 'react';
+import {FormattedMessage} from 'react-intl';
+
+export default class Foo extends Component {
+    render() {
+        return (
+            <div>
+                <FormattedMessage
+                    id='lorem_ipsum'
+                    defaultMessage='Lorem ipsum'
+                />
+                <FormattedMessage
+                    id='foo.aar'
+                    defaultMessage='foo aar'
+                />
+            </div>
+        );
+    }
+}

--- a/test/fixtures/messagesStructureCategory/expected-default.json
+++ b/test/fixtures/messagesStructureCategory/expected-default.json
@@ -1,0 +1,10 @@
+{
+  "hello_world": {
+    "id": "hello_world",
+    "defaultMessage": "Hello World!"
+  },
+  "lorem_ipsum": {
+    "id": "lorem_ipsum",
+    "defaultMessage": "Lorem ipsum"
+  }
+}

--- a/test/fixtures/messagesStructureCategory/expected-foo.json
+++ b/test/fixtures/messagesStructureCategory/expected-foo.json
@@ -1,0 +1,10 @@
+{
+  "foo.bar.baz": {
+    "id": "foo.bar.baz",
+    "defaultMessage": "foo bar baz"
+  },
+  "foo.aar": {
+    "id": "foo.aar",
+    "defaultMessage": "foo aar"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,7 @@ const skipTests = [
     'moduleSourceName',
     'icuSyntax',
     'removeDescriptions',
+    'enforceDefaultMessages',
 ];
 
 const fixturesDir = path.join(__dirname, 'fixtures');
@@ -67,6 +68,34 @@ describe('options', () => {
         try {
             transform(path.join(fixtureDir, 'actual.js'), {
                 enforceDescriptions: false,
+            });
+            assert(true);
+        } catch (e) {
+            console.error(e);
+            assert(false);
+        }
+    });
+
+    it('enforces defaultMessages when enforceDefaultMessages=true', () => {
+        const fixtureDir = path.join(fixturesDir, 'enforceDefaultMessages');
+
+        try {
+            transform(path.join(fixtureDir, 'actual.js'), {
+                enforceDefaultMessages: true,
+            });
+            assert(false);
+        } catch (e) {
+            assert(e);
+            assert(/Message Descriptors require a `defaultMessage`/.test(e.message));
+        }
+    });
+
+    it('allows no defaultMessage when enforceDefaultMessages=false', () => {
+        const fixtureDir = path.join(fixturesDir, 'enforceDefaultMessages');
+
+        try {
+            transform(path.join(fixtureDir, 'actual.js'), {
+                enforceDefaultMessages: false,
             });
             assert(true);
         } catch (e) {

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,7 @@ const skipTests = [
     '.DS_Store',
     'enforceDescriptions',
     'extractSourceLocation',
+    'extractInjectionApi',
     'moduleSourceName',
     'icuSyntax',
     'removeDescriptions',
@@ -166,6 +167,25 @@ describe('options', () => {
         try {
             transform(path.join(fixtureDir, 'actual.js'), {
                 extractSourceLocation: true,
+            });
+            assert(true);
+        } catch (e) {
+            console.error(e);
+            assert(false);
+        }
+
+        // Check message output
+        const expectedMessages = fs.readFileSync(path.join(fixtureDir, 'expected.json'));
+        const actualMessages = fs.readFileSync(path.join(fixtureDir, 'actual.json'));
+        assert.equal(trim(actualMessages), trim(expectedMessages));
+    });
+
+    it('respects extractInjectionApi', () => {
+        const fixtureDir = path.join(fixturesDir, 'extractInjectionApi');
+
+        try {
+            transform(path.join(fixtureDir, 'actual.js'), {
+                extractInjectionApi: true,
             });
             assert(true);
         } catch (e) {

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ const skipTests = [
     'removeDescriptions',
     'enforceDefaultMessages',
     'componentNames',
+    'messagesStructureCategory',
 ];
 
 const fixturesDir = path.join(__dirname, 'fixtures');
@@ -197,6 +198,39 @@ describe('options', () => {
         const expectedMessages = fs.readFileSync(path.join(fixtureDir, 'expected.json'));
         const actualMessages = fs.readFileSync(path.join(fixtureDir, 'actual.json'));
         assert.equal(trim(actualMessages), trim(expectedMessages));
+    });
+
+    it('exports messages by category, when messagesStructure=category', () => {
+        const fixtureDir = path.join(fixturesDir, 'messagesStructureCategory');
+
+        try {
+            transform(path.join(fixtureDir, 'actual.js'), {
+                messagesStructure: 'category',
+                messagesDir: fixtureDir,
+            });
+            assert(true);
+        } catch (e) {
+            console.error(e);
+            assert(false);
+        }
+
+        try {
+            transform(path.join(fixtureDir, 'actual2.js'), {
+                messagesStructure: 'category',
+                messagesDir: fixtureDir,
+            });
+            assert(true);
+        } catch (e) {
+            console.error(e);
+            assert(false);
+        }
+
+        ['default', 'foo'].forEach((category) => {
+            // Check message output
+            const expectedMessages = fs.readFileSync(path.join(fixtureDir, `expected-${category}.json`));
+            const actualMessages = fs.readFileSync(path.join(fixtureDir, `${category}.json`));
+            assert.equal(trim(actualMessages), trim(expectedMessages));
+        });
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,7 @@ const skipTests = [
     'icuSyntax',
     'removeDescriptions',
     'enforceDefaultMessages',
+    'componentNames',
 ];
 
 const fixturesDir = path.join(__dirname, 'fixtures');
@@ -126,6 +127,26 @@ describe('options', () => {
         try {
             transform(path.join(fixtureDir, 'actual.js'), {
                 moduleSourceName: 'react-i18n',
+            });
+            assert(true);
+        } catch (e) {
+            console.error(e);
+            assert(false);
+        }
+
+        // Check message output
+        const expectedMessages = fs.readFileSync(path.join(fixtureDir, 'expected.json'));
+        const actualMessages = fs.readFileSync(path.join(fixtureDir, 'actual.json'));
+        assert.equal(trim(actualMessages), trim(expectedMessages));
+    });
+
+    it('respects componentNames', () => {
+        const fixtureDir = path.join(fixturesDir, 'componentNames');
+
+        try {
+            transform(path.join(fixtureDir, 'actual.js'), {
+                moduleSourceName: 'react-i18n',
+                componentNames: ['default', 'Message'],
             });
             assert(true);
         } catch (e) {


### PR DESCRIPTION
This is a first attempt to implement the things, I've described in #128.

This PR includes:

* an option to allow messages with only `id` (without `defaultMessage`)
* an options to override default component names (#138)
* an option to allow parsing messages from imperative api (#18)
* an option to merge all messages into several files by 'category' specified in message id.