### PR TITLE
Move upath from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "intl-messageformat-parser": "^1.2.0",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "upath": "^1.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
@@ -30,7 +31,6 @@
     "mocha": "^3.0.2",
     "power-assert": "^1.4.1",
     "rimraf": "^2.4.3",
-    "upath": "^1.1.0",
     "uuid": "^3.3.2"
   },
   "scripts": {


### PR DESCRIPTION
Closes #151. 

I am now having this error
`{ Error: Cannot find module 'babel-plugin-react-intl' from '/Volumes/sites/monyl' - If you want to resolve "react-intl", use "module:react-intl"` I do not think it is related to this commit.